### PR TITLE
Homepage image slideshow & content

### DIFF
--- a/_data/images.yml
+++ b/_data/images.yml
@@ -1,4 +1,9 @@
 # URL keys to images stored on google drive
+# Properties:
+# - title: title of image for screen readers or an overlay
+# - url: the unique url key from google drive retrieved from the shareable link
+# - style: any custom style to apply to the html <img> element
+# - active: the initial photo to display (only apply this to one)
 
 - title: 3D Printer Cup
   url: 0B3zdoDC33IO_Z1MyTFNva0FpdlE
@@ -10,3 +15,6 @@
 
 - title: Line Following Arch
   url: 0B3zdoDC33IO_eUNQRktIVklJUkE
+
+- title: Line Following Arch 2
+  url: 0B3zdoDC33IO_c05UdmNtdGtCRm8

--- a/_data/images.yml
+++ b/_data/images.yml
@@ -1,0 +1,12 @@
+# URL keys to images stored on google drive
+
+- title: 3D Printer Cup
+  url: 0B3zdoDC33IO_Z1MyTFNva0FpdlE
+  style: "transform: rotate(90deg);"
+  active: true
+
+- title: Open Day Printer
+  url: 0B3zdoDC33IO_dldlcGxTTDZ5WjQ
+
+- title: Line Following Arch
+  url: 0B3zdoDC33IO_eUNQRktIVklJUkE

--- a/_data/images.yml
+++ b/_data/images.yml
@@ -14,7 +14,10 @@
   url: 0B3zdoDC33IO_dldlcGxTTDZ5WjQ
 
 - title: Line Following Arch
-  url: 0B3zdoDC33IO_eUNQRktIVklJUkE
-
-- title: Line Following Arch 2
   url: 0B3zdoDC33IO_c05UdmNtdGtCRm8
+
+- title: NI ARC 2015
+  url: 0B3zdoDC33IO_ZFJseWgxcG5Pak0
+  
+- title: Sausage Sizzle
+  url: 0B3zdoDC33IO_T3JHb2FyUTNzTm8

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -18,11 +18,11 @@
               {% if p.includenav %} <!-- only include desired pages -->
                 <li {% if p.title == page.title %}class="active"{% endif%}>
                   <a href="{{ p.url | remove: '.html' }}">
-                      {% if p.navtitle %}
-                          {{ p.navtitle }}
-                      {% else %}
-                          {{ p.title }}
-                      {% endif %}
+                    {% if p.navtitle %}
+                      {{ p.navtitle }}
+                    {% else %}
+                      {{ p.title }}
+                    {% endif %}
                   </a>
                 </li>
               {% endif %}

--- a/css/main.scss
+++ b/css/main.scss
@@ -53,6 +53,26 @@ footer > .container {
   background-color: #f5f5f5;
 }
 
+.panel-inverse {
+  border-color: #333 !important;
+  .panel-heading {
+    color: #9d9d9d;
+    border-color: #222;
+    background-color: #222;
+  }
+}
+
+.btn-inverse {
+  color: #9d9d9d;
+  background-color: #222;
+  border-color: #222 !important;
+}
+
+.btn-inverse:hover, .btn-inverse:focus {
+  color: #fff !important;
+  background-color: #000; // or maybe leave background when focus/hover
+}
+
 .text-muted {
   color: #777;
 }

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 layout: homepage
 ---
 
-<div class="jumbotron"> <!-- or .well? -->
+<div class="jumbotron">
 	<h2>The {{site.title}}</h2>
 	<p>A member run Guild club that's about everything robotics.</p>
 </div>
@@ -10,22 +10,22 @@ layout: homepage
 <div class="row">
 	<div class="col-md-10 col-md-offset-1">
 		<div class="well">
-		<div id="slides" class="carousel slide" data-ride="carousel">
-			<ol class="carousel-indicators">
-				<li data-target="#slides" data-slide-to="0" class="active"></li>
-				<li data-target="#slides" data-slide-to="1"></li>
-				<li data-target="#slides" data-slide-to="2"></li>
-			</ol>
-			<div class="carousel-inner" role="listbox" style="max-height: 400px;">
-				{% for image in site.data.images %}
-					<div class="item {% if image.active %}active{% endif %}">
-						<img {% if image.style %}style="{{ image.style }}"{% endif %} src="https://docs.google.com/uc?authuser=0&id={{ image.url }}&export=download" alt="{{ image.title }}"/>
-					</div>
-				{% endfor %}
+			<div id="slides" class="carousel slide" data-ride="carousel">
+				<ol class="carousel-indicators">
+					{% for image in site.data.images %}
+					<li data-target="#slides" data-slide-to="{{ forloop.index | minus: 1 }}" {% if image.active %}class="active"{% endif %}></li>
+					{% endfor %}
+				</ol>
+				<div class="carousel-inner" role="listbox" style="max-height: 500px;">
+					{% for image in site.data.images %}
+						<div class="item {% if image.active %}active{% endif %}">
+							<img {% if image.style %}style="{{ image.style }}"{% endif %} src="https://docs.google.com/uc?authuser=0&id={{ image.url }}&export=download" alt="{{ image.title }}"/>
+						</div>
+					{% endfor %}
+				</div>
+				<a class="left carousel-control" href="#slides" role="button" data-slide="prev"><i class="glyphicon glyphicon-chevron-left"></i></a>
+				<a class="right carousel-control" href="#slides" role="button" data-slide="next"><i class="glyphicon glyphicon-chevron-right"></i></a>
 			</div>
-			<a class="left carousel-control" href="#slides" role="button" data-slide="prev"><i class="glyphicon glyphicon-chevron-left"></i></a>
-			<a class="right carousel-control" href="#slides" role="button" data-slide="next"><i class="glyphicon glyphicon-chevron-right"></i></a>
 		</div>
 	</div>
-</div>
 </div>

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@ layout: homepage
 			<div id="slides" class="carousel slide" data-ride="carousel">
 				<ol class="carousel-indicators">
 					{% for image in site.data.images %}
-					<li data-target="#slides" data-slide-to="{{ forloop.index | minus: 1 }}" {% if image.active %}class="active"{% endif %}></li>
+					<li data-target="#slides" data-slide-to="{{ forloop.index | minus: 1 }}" {% if image.active %}class="active"{% endif %}></li>					
 					{% endfor %}
 				</ol>
 				<div class="carousel-inner" role="listbox" style="max-height: 500px;">
@@ -32,7 +32,7 @@ layout: homepage
 
 <div class="row">
 	<div class="col-md-9 col-sm-8 col-xs-12">
-		Placeholder text for a description and brief overview of the club. Also include some info about what this site is about. Joining croc, projects that we do, equipment we have access to. Is there anything else?
+		Curtin Robotics Club (CRoC) is a club for people who love to create and build electronic projects. We as a club build robots, participate in robotics competitions, teach high school students to build a robot with Engineering Outreach, and much more. Our objective is to create a club and a fun environment for students who share the same interest.
 	</div>
 	<div class="col-md-3 col-sm-4 col-xs-12">
 		<div class="panel panel-inverse">

--- a/index.html
+++ b/index.html
@@ -7,4 +7,25 @@ layout: homepage
 	<p>A member run Guild club that's about everything robotics.</p>
 </div>
 
-<!-- insert carousel of images? -->
+<div class="row">
+	<div class="col-md-10 col-md-offset-1">
+		<div class="well">
+		<div id="slides" class="carousel slide" data-ride="carousel">
+			<ol class="carousel-indicators">
+				<li data-target="#slides" data-slide-to="0" class="active"></li>
+				<li data-target="#slides" data-slide-to="1"></li>
+				<li data-target="#slides" data-slide-to="2"></li>
+			</ol>
+			<div class="carousel-inner" role="listbox" style="max-height: 400px;">
+				{% for image in site.data.images %}
+					<div class="item {% if image.active %}active{% endif %}">
+						<img {% if image.style %}style="{{ image.style }}"{% endif %} src="https://docs.google.com/uc?authuser=0&id={{ image.url }}&export=download" alt="{{ image.title }}"/>
+					</div>
+				{% endfor %}
+			</div>
+			<a class="left carousel-control" href="#slides" role="button" data-slide="prev"><i class="glyphicon glyphicon-chevron-left"></i></a>
+			<a class="right carousel-control" href="#slides" role="button" data-slide="next"><i class="glyphicon glyphicon-chevron-right"></i></a>
+		</div>
+	</div>
+</div>
+</div>

--- a/index.html
+++ b/index.html
@@ -29,3 +29,21 @@ layout: homepage
 		</div>
 	</div>
 </div>
+
+<div class="row">
+	<div class="col-md-9 col-sm-8 col-xs-12">
+		Placeholder text for a description and brief overview of the club. Also include some info about what this site is about. Joining croc, projects that we do, equipment we have access to. Is there anything else?
+	</div>
+	<div class="col-md-3 col-sm-4 col-xs-12">
+		<div class="panel panel-inverse">
+			<div class="panel-heading">Site Navigation</div>
+			<div class="list-group">
+				{% for p in site.pages %}
+					{% if p.title %}
+						<a href="{{p.url | remove: '.html'}}" class="list-group-item">{{p.title}}</a>
+					{% endif %}
+				{% endfor %}
+			</div>
+		</div>
+	</div>
+</div>

--- a/minutes.html
+++ b/minutes.html
@@ -1,5 +1,5 @@
 ---
-title: Minutes & Agendas
+title: Meeting Minutes
 layout: default
 excerpt: Curtin Robotics Club meeting minutes.
 ---


### PR DESCRIPTION
Close #6, close #10. Images hosted on google drive (and publicly shared) can now be easily included on the homepage slideshow. There are currently 4. To add any more, find the unique url and add it to the _data/images.yml file and it will automatically be added to the homepage. @Tapego can you check this out branch out and merge it in if you like it. Let me know if you need help testing it
